### PR TITLE
Feature: Asset References

### DIFF
--- a/.github/codecov.yml
+++ b/.github/codecov.yml
@@ -12,6 +12,7 @@ coverage:
     project:
       default:
         informational: true
+    patch: off
 
 comment:
   layout: "reach,diff,flags,files,footer"

--- a/.github/workflows/build.ci.yml
+++ b/.github/workflows/build.ci.yml
@@ -88,7 +88,7 @@ jobs:
             --scan
             --dependency-verification=lenient
             -Pelide.ci=true
-            -PbuildSamples=false
+            -PbuildSamples=true
             -Pversions.java.language=${{ matrix.java }}
 
       ## CI: Build
@@ -134,6 +134,7 @@ jobs:
             --dependency-verification=strict
             :tools:reports:reports
             -Pelide.ci=true
+            -PbuildSamples=true
             -Pversions.java.language=17
             -x nativeCompile
             -x :packages:graalvm:test

--- a/packages/server/build.gradle.kts
+++ b/packages/server/build.gradle.kts
@@ -133,6 +133,15 @@ tasks.jacocoTestReport {
 
 micronaut {
   version.set(libs.versions.micronaut.lib.get())
+  processing {
+    incremental.set(true)
+    annotations.addAll(listOf(
+      "elide.server",
+      "elide.server.*",
+      "elide.server.annotations",
+      "elide.server.annotations.*",
+    ))
+  }
 }
 
 dependencies {
@@ -143,6 +152,8 @@ dependencies {
   api(platform(libs.netty.bom))
 
   // Modules
+  kapt(libs.micronaut.inject)
+  kapt(libs.micronaut.inject.java)
   implementation(project(":packages:base"))
   implementation(project(":packages:proto"))
 
@@ -211,6 +222,8 @@ dependencies {
   implementation(libs.reactivestreams)
 
   // Testing
+  kaptTest(libs.micronaut.inject)
+  kaptTest(libs.micronaut.inject.java)
   testImplementation(libs.truth)
   testImplementation(libs.truth.java8)
   testImplementation(libs.truth.proto)

--- a/packages/server/src/main/kotlin/elide/server/PageExtensions.kt
+++ b/packages/server/src/main/kotlin/elide/server/PageExtensions.kt
@@ -1,16 +1,42 @@
-@file:Suppress("NOTHING_TO_INLINE", "unused")
+@file:Suppress("unused")
 
 package elide.server
 
+import elide.server.assets.AssetReference
 import kotlinx.html.BODY
 import kotlinx.html.HEAD
 import kotlinx.html.LINK
 import kotlinx.html.SCRIPT
 import kotlinx.html.attributesMapOf
 import kotlinx.html.visit
+import java.util.SortedMap
+
+// DOM type for JavaScript files.
+private const val JAVASCRIPT_TYPE = "application/javascript"
+
+/** Generate a stylesheet link from an embedded server [asset], optionally with the provided [media] declaration. */
+public fun HEAD.stylesheet(
+  asset: AssetReference,
+  media: String? = null,
+  attrs: SortedMap<String, String>? = null
+): Unit = LINK(
+  attributesMapOf(
+    "rel",
+    "stylesheet",
+    "href",
+    asset.href,
+  ).plus(
+    attrs ?: emptyMap()
+  ),
+  consumer
+).visit {
+  if (media?.isNotBlank() == true) {
+    this.media = media
+  }
+}
 
 /** Generates a CSS link from the provided handler [uri], optionally including the specified [attrs]. */
-public inline fun HEAD.stylesheet(uri: String, media: String? = null, attrs: Map<String, String>? = null): Unit = LINK(
+public fun HEAD.stylesheet(uri: String, media: String? = null, attrs: Map<String, String>? = null): Unit = LINK(
   attributesMapOf(
     "rel",
     "stylesheet",
@@ -26,12 +52,36 @@ public inline fun HEAD.stylesheet(uri: String, media: String? = null, attrs: Map
   }
 }
 
+/** Generates a `<head>` script link from the provided [asset], optionally including the specified [attrs], etc. */
+public fun HEAD.script(
+  asset: AssetReference,
+  defer: Boolean = false,
+  async: Boolean = false,
+  nomodule: Boolean = false,
+  type: String = JAVASCRIPT_TYPE,
+  attrs: Map<String, String>? = null,
+): Unit = SCRIPT(
+  attributesMapOf(
+    "type",
+    type,
+    "src",
+    asset.href,
+  ).plus(
+    attrs ?: emptyMap()
+  ),
+  consumer
+).visit {
+  if (defer) this.defer = true
+  if (async) this.async = true
+  if (nomodule) this.attributes["nomodule"] = ""
+}
+
 /** Generates a `<head>` script link from the provided handler [uri], optionally including the specified [attrs]. */
-public inline fun HEAD.script(
+public fun HEAD.script(
   uri: String,
   defer: Boolean = false,
   async: Boolean = false,
-  type: String = "application/javascript",
+  type: String = JAVASCRIPT_TYPE,
   attrs: Map<String, String>? = null,
 ): Unit = SCRIPT(
   attributesMapOf(
@@ -48,13 +98,12 @@ public inline fun HEAD.script(
   if (async) this.async = true
 }
 
-
 /** Generates a `<body>` script link from the provided handler [uri], optionally including the specified [attrs]. */
-public inline fun BODY.script(
+public fun BODY.script(
   uri: String,
   defer: Boolean = false,
   async: Boolean = false,
-  type: String = "application/javascript",
+  type: String = JAVASCRIPT_TYPE,
   attrs: Map<String, String>? = null,
 ): Unit = SCRIPT(
   attributesMapOf(
@@ -62,6 +111,28 @@ public inline fun BODY.script(
     type,
     "src",
     uri
+  ).plus(
+    attrs ?: emptyMap()
+  ),
+  consumer
+).visit {
+  if (defer) this.defer = true
+  if (async) this.async = true
+}
+
+/** Generates a `<body>` script link from the provided [asset], optionally including the specified [attrs], etc. */
+public fun BODY.script(
+  asset: AssetReference,
+  defer: Boolean = false,
+  async: Boolean = false,
+  type: String = JAVASCRIPT_TYPE,
+  attrs: Map<String, String>? = null,
+): Unit = SCRIPT(
+  attributesMapOf(
+    "type",
+    type,
+    "src",
+    asset.href,
   ).plus(
     attrs ?: emptyMap()
   ),

--- a/packages/server/src/main/kotlin/elide/server/assets/AssetPointer.kt
+++ b/packages/server/src/main/kotlin/elide/server/assets/AssetPointer.kt
@@ -8,10 +8,18 @@ import java.util.SortedSet
  *
  * @param moduleId Developer-assigned ID for this asset module.
  * @param type Type of asset represented by this reference.
+ * @param token Full-length Asset Tag (referred to as the "asset token").
+ * @param tag Generated asset tag (fingerprint) for this asset, in full (untrimmed) form.
+ * @param etag Computed ETag for this asset.
+ * @param modified Last-modified time for this asset; set to `-1` to indicate "unknown".
  * @param index Index of the asset within the asset content payload list of the active asset bundle.
  */
-internal data class AssetPointer(
+public data class AssetPointer(
   val moduleId: AssetModuleId,
   val type: AssetType,
+  val token: String,
+  val tag: String,
+  val etag: String,
+  val modified: Long,
   val index: SortedSet<Int>?,
 ) : java.io.Serializable

--- a/packages/server/src/main/kotlin/elide/server/assets/AssetReader.kt
+++ b/packages/server/src/main/kotlin/elide/server/assets/AssetReader.kt
@@ -1,6 +1,7 @@
 package elide.server.assets
 
 import elide.annotations.API
+import elide.server.AssetModuleId
 import io.micronaut.http.HttpRequest
 import kotlinx.coroutines.Deferred
 import java.io.FileNotFoundException
@@ -57,4 +58,13 @@ import java.io.FileNotFoundException
    */
   @Throws(FileNotFoundException::class)
   public suspend fun readAsync(descriptor: ServerAsset, request: HttpRequest<*>): Deferred<RenderedAsset>
+
+  /**
+   * Resolve a reference to an asset identified by the provided [moduleId], in the form of an [AssetPointer]; if no
+   * matching asset can be found, return `null` to indicate a not-found failure.
+   *
+   * @param moduleId ID of the module which we should resolve from the active asset bundle.
+   * @return Asset pointer resolved for the provided [moduleId], or `null`.
+   */
+  public fun pointerTo(moduleId: AssetModuleId): AssetPointer?
 }

--- a/packages/server/src/main/kotlin/elide/server/assets/AssetReference.kt
+++ b/packages/server/src/main/kotlin/elide/server/assets/AssetReference.kt
@@ -1,0 +1,32 @@
+package elide.server.assets
+
+import elide.server.AssetModuleId
+import kotlinx.serialization.Serializable
+
+/**
+ * Represents a resolved reference to an asset at serving-time, before it is rendered into a link or other tag.
+ *
+ * @param module ID of the asset module being referenced.
+ * @param assetType Type of asset being referenced.
+ * @param href Relative link to serve the asset.
+ * @param type Type override for the tag, if applicable.
+ * @param inline Whether this asset is eligible to be inlined into the page.
+ * @param preload Whether this asset is eligible to be preloaded.
+ */
+@Serializable public data class AssetReference(
+  val module: AssetModuleId,
+  val assetType: AssetType,
+  val href: String,
+  val type: String? = null,
+  val inline: Boolean = false,
+  val preload: Boolean = false,
+) : java.io.Serializable {
+  internal companion object {
+    /** @return [AssetReference] from the specified [pointer]. */
+    @JvmStatic internal fun fromPointer(pointer: AssetPointer, uri: String): AssetReference = AssetReference(
+      module = pointer.moduleId,
+      assetType = pointer.type,
+      href = uri,
+    )
+  }
+}

--- a/packages/server/src/main/kotlin/elide/server/cfg/AssetConfig.kt
+++ b/packages/server/src/main/kotlin/elide/server/cfg/AssetConfig.kt
@@ -8,10 +8,12 @@ import io.micronaut.context.annotation.ConfigurationProperties
  * @param enabled Whether the asset system is enabled.
  * @param prefix URI prefix where static assets are served.
  * @param etags Whether to generate, and respond to, ETag headers for assets.
+ * @param preferWeakEtags Whether to prefer weak ETags. Defaults to `false`.
  */
 @ConfigurationProperties("elide.server.assets")
 public data class AssetConfig(
   public var enabled: Boolean = true,
   public var prefix: String = "/_/assets",
   public var etags: Boolean = true,
+  public var preferWeakEtags: Boolean = false,
 )

--- a/packages/server/src/test/kotlin/elide/server/assets/AssetDataTest.kt
+++ b/packages/server/src/test/kotlin/elide/server/assets/AssetDataTest.kt
@@ -23,6 +23,10 @@ class AssetDataTest {
     val pointer = AssetPointer(
       moduleId = "some-module",
       type = AssetType.SCRIPT,
+      token = "some-token-some-tag",
+      tag = "some-tag",
+      etag = "W/\"some-etag\"",
+      modified = 123L,
       index = null,
     )
     assertNull(
@@ -34,14 +38,22 @@ class AssetDataTest {
     val pointer = AssetPointer(
       moduleId = "some-module",
       type = AssetType.SCRIPT,
+      token = "some-token-some-tag",
+      tag = "some-tag",
+      etag = "W/\"some-etag\"",
+      modified = 123L,
       index = sortedSetOf(5),
     )
     assertEquals("some-module", pointer.moduleId)
+    assertEquals("some-token-some-tag", pointer.token)
+    assertEquals("some-tag", pointer.tag)
     assertEquals(AssetType.SCRIPT, pointer.type)
     assertEquals(5, pointer.index!!.first())
     assertEquals(pointer, pointer)
     assertEquals(pointer, pointer.copy())
     assertNotNull(pointer.hashCode())
+    assertEquals("W/\"some-etag\"", pointer.etag)
+    assertEquals(123L, pointer.modified)
     assertTrue(pointer.toString().contains("some-module"))
   }
 
@@ -95,5 +107,63 @@ class AssetDataTest {
     assertNotNull(asset.digest)
     assertEquals(asset, asset)
     assertNotNull(asset.hashCode())
+  }
+
+  @Test fun testAssetReferenceDefaults() {
+    val ref = AssetReference(
+      module = "some-module",
+      assetType = AssetType.STYLESHEET,
+      href = "/_/assets/some-path.css",
+    )
+    assertEquals(ref.module, "some-module")
+    assertEquals(ref.assetType, AssetType.STYLESHEET)
+    assertEquals(ref.href, "/_/assets/some-path.css")
+
+    // type should be `null` and `inline` should be not be `null` by default.
+    assertNull(ref.type)
+    assertNotNull(ref.inline)
+    assertNotNull(ref.preload)
+  }
+
+  @Test fun testAssetReference() {
+    val ref = AssetReference(
+      module = "some-module",
+      assetType = AssetType.STYLESHEET,
+      href = "/_/assets/some-path.css",
+      type = "type-override",
+      inline = true,
+    )
+    assertEquals(ref.module, "some-module")
+    assertEquals(ref.assetType, AssetType.STYLESHEET)
+    assertEquals(ref.href, "/_/assets/some-path.css")
+    assertEquals(ref.type, "type-override")
+    assertTrue(ref.inline)
+    assertNotNull(AssetReference.serializer())
+    assertEquals(ref, ref)
+    assertEquals(ref, ref.copy())
+    val json = Json.encodeToString(AssetReference.serializer(), ref)
+    assertNotNull(json)
+    val inflated = Json.decodeFromString(AssetReference.serializer(), json)
+    assertNotNull(inflated)
+    assertEquals(ref, inflated)
+  }
+
+  @Test fun testAssetReferenceFromPointer() {
+    val pointer = AssetPointer(
+      moduleId = "some-module",
+      type = AssetType.SCRIPT,
+      token = "some-token-some-tag",
+      tag = "some-tag",
+      etag = "W/\"some-etag\"",
+      modified = 123L,
+      index = sortedSetOf(5),
+    )
+    val reference = AssetReference.fromPointer(
+      pointer,
+      "/_/assets/some-uri.js"
+    )
+    assertNotNull(reference)
+    assertEquals(reference.module, "some-module")
+    assertEquals(reference.assetType, AssetType.SCRIPT)
   }
 }

--- a/packages/server/src/test/kotlin/elide/server/cfg/AssetConfigTest.kt
+++ b/packages/server/src/test/kotlin/elide/server/cfg/AssetConfigTest.kt
@@ -12,6 +12,7 @@ class AssetConfigTest {
     assertNotNull(cfg.prefix)
     assertTrue(cfg.enabled)
     assertTrue(cfg.etags)
+    assertFalse(cfg.preferWeakEtags)
 
     // asset config should be mutable
     cfg.enabled = false
@@ -23,5 +24,7 @@ class AssetConfigTest {
     )
     cfg.etags = false
     assertFalse(cfg.etags)
+    cfg.preferWeakEtags = true
+    assertTrue(cfg.preferWeakEtags)
   }
 }

--- a/packages/server/src/test/kotlin/elide/server/cfg/ServerConfigTest.kt
+++ b/packages/server/src/test/kotlin/elide/server/cfg/ServerConfigTest.kt
@@ -10,7 +10,9 @@ class ServerConfigTest {
     val config = ServerConfig()
     assertNotNull(config)
     assertNotNull(config.assets)
-    val assetsDisabled = AssetConfig(enabled = false)
+    val assetsDisabled = AssetConfig().copy(
+      enabled = false
+    )
     config.assets = assetsDisabled
     assertFalse(config.assets.enabled)
   }

--- a/packages/server/src/test/kotlin/elide/server/controller/PageControllerTest.kt
+++ b/packages/server/src/test/kotlin/elide/server/controller/PageControllerTest.kt
@@ -1,0 +1,214 @@
+package elide.server.controller
+
+import elide.server.assets.AssetReference
+import elide.server.assets.AssetType
+import io.micronaut.http.HttpRequest
+import io.micronaut.http.HttpResponse
+import io.micronaut.test.extensions.junit5.annotation.MicronautTest
+import jakarta.inject.Inject
+import kotlinx.coroutines.runBlocking
+import org.junit.jupiter.api.assertDoesNotThrow
+import org.junit.jupiter.api.assertThrows
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertNotNull
+import kotlin.test.assertTrue
+
+/** Tests for the top-level [PageController] extension point. */
+@MicronautTest class PageControllerTest {
+  // Application bean context.
+  @Inject lateinit var sample: SamplePageController
+
+  private fun assetResponse(response: HttpResponse<*>?, contentType: String? = null) {
+    assertNotNull(response)
+    assertEquals(200, response.status.code)
+    assertTrue(response.headers.contains("Content-Type"))
+    if (contentType != null) {
+      assertTrue(response.headers.get("Content-Type")!!.contains(contentType))
+    }
+  }
+
+  @Test fun testInjectable() {
+    assertNotNull(sample)
+  }
+
+  @Test fun testGenerateAssetReferenceInvalid() {
+    assertThrows<IllegalArgumentException> {
+      sample.asset("some-invalid-module")
+    }
+  }
+
+  @Test fun testGenerateReferenceValid() {
+    assertNotNull(
+      assertDoesNotThrow {
+        sample.asset("styles.base")
+      },
+      "acquiring a known-good asset reference should not produce `null` or throw"
+    )
+  }
+
+  @Test fun testGenerateReferenceModuleIdRequired() {
+    assertThrows<IllegalArgumentException> {
+      sample.asset("")
+    }
+    assertThrows<IllegalArgumentException> {
+      sample.asset(" ")
+    }
+    assertThrows<IllegalArgumentException> {
+      sample.asset("") {
+        // nothing
+      }
+    }
+    assertThrows<IllegalArgumentException> {
+      sample.asset(" ") {
+        // nothing
+      }
+    }
+    assertThrows<IllegalArgumentException> {
+      sample.asset("styles.base") {
+        module = ""
+      }
+    }
+  }
+
+  @Test fun testAssignmentToUtilities() {
+    assertDoesNotThrow {
+      sample.assetManager = sample.assetManager
+      sample.appContext = sample.appContext
+    }
+  }
+
+  @Test fun testGenerateReferenceViaHandler() {
+    val ref = assertDoesNotThrow {
+      sample.asset("styles.base") {
+        module = "styles.base"
+        inline = true
+        preload = true
+      }
+    }
+
+    assertNotNull(ref, "customizing an asset reference should not produce `null`")
+    assertEquals(
+      AssetReference(
+        module = "styles.base",
+        assetType = AssetType.STYLESHEET,
+        href = ref.href,
+        type = null,
+        inline = true,
+        preload = true,
+      ),
+      ref,
+      "should be able to customize an asset reference with a handler"
+    )
+  }
+
+  @Test fun testCanAcquireAssetManager() {
+    assertNotNull(
+      sample.assets(),
+      "`PageController` inheritors should be able to acquire the asset runtime"
+    )
+  }
+
+  @Test fun testCanAcquireAppContext() {
+    assertNotNull(
+      sample.context(),
+      "`PageController` inheritors should be able to acquire the app context"
+    )
+  }
+
+  @Test fun testRenderHtmlPage() {
+    assetResponse(
+      assertDoesNotThrow {
+        runBlocking {
+          sample.indexPage(HttpRequest.GET<Any>("/"))
+        }
+      }
+    )
+  }
+
+  @Test fun testRenderCssDocument() {
+    assetResponse(
+      assertDoesNotThrow {
+        runBlocking {
+          sample.styles()
+        }
+      }
+    )
+  }
+
+  @Test fun testRenderStylesheetAssetWithHandler() {
+    assetResponse(
+      assertDoesNotThrow {
+        runBlocking {
+          sample.assetStyle(HttpRequest.GET("/styles/base.css"))
+        }
+      }
+    )
+  }
+
+  @Test fun testRenderStylesheetAssetWithKnownModule() {
+    assetResponse(
+      assertDoesNotThrow {
+        runBlocking {
+          sample.assetStyleExplicit(HttpRequest.GET("/styles/base.other.css"))
+        }
+      }
+    )
+  }
+
+  @Test fun testRenderStylesheetAssetWithGenericCall() {
+    assetResponse(
+      assertDoesNotThrow {
+        runBlocking {
+          sample.assetGeneric(HttpRequest.GET("/styles/base.another.css"))
+        }
+      }
+    )
+  }
+
+  @Test fun testRenderScriptAssetWithHandler() {
+    assetResponse(
+      assertDoesNotThrow {
+        runBlocking {
+          sample.assetScript(HttpRequest.GET("/scripts/ui.js"))
+        }
+      }
+    )
+  }
+
+  @Test fun testRenderScriptAssetWithKnownModule() {
+    assetResponse(
+      assertDoesNotThrow {
+        runBlocking {
+          sample.assetScriptExplicit(HttpRequest.GET("/scripts/ui.other.js"))
+        }
+      }
+    )
+  }
+
+  @Test fun testRenderTextStaticResource() {
+    assetResponse(
+      assertDoesNotThrow {
+        runBlocking {
+          sample.somethingText()
+        }
+      },
+      "text/plain"
+    )
+  }
+
+  @Test fun testNotFoundStaticFile() {
+    val response = assertDoesNotThrow {
+      runBlocking {
+        sample.somethingMissing()
+      }
+    }
+    assertNotNull(
+      response
+    )
+    assertEquals(
+      404,
+      response.status.code
+    )
+  }
+}

--- a/packages/server/src/test/kotlin/elide/server/controller/SamplePageController.kt
+++ b/packages/server/src/test/kotlin/elide/server/controller/SamplePageController.kt
@@ -1,0 +1,85 @@
+package elide.server.controller
+
+import elide.server.*
+import elide.server.annotations.Page
+import elide.server.assets.AssetType
+import io.micronaut.http.HttpRequest
+import io.micronaut.http.annotation.Get
+import kotlinx.css.*
+import kotlinx.html.strong
+import kotlinx.html.tagext.body
+import kotlinx.html.tagext.head
+import kotlinx.html.title
+
+/** Sample page controller for testing. */
+@Page class SamplePageController : PageController() {
+  @Get("/") suspend fun indexPage(request: HttpRequest<*>) = html {
+    head {
+      title { +"Hello, Elide!" }
+      stylesheet(asset("styles.base"), media = "screen", attrs = sortedMapOf("hello" to "cool"))
+      stylesheet(asset("styles.base"))
+      script(
+        asset("scripts.ui"),
+        async = true,
+        defer = true,
+        nomodule = true,
+        attrs = sortedMapOf(
+          "extra" to "attr",
+        )
+      )
+      script(asset("scripts.ui"))
+      stylesheet("/styles/base.css")
+      script("/scripts/ui.js", defer = true)
+    }
+    body {
+      strong {
+        +"Hello Sample Page!"
+      }
+      script(asset("scripts.ui"))
+      script("/scripts/ui.js", defer = true)
+    }
+  }
+
+  @Get("/some-styles.css") suspend fun styles() = css {
+    rule("main") {
+      backgroundColor = Color.white
+      maxWidth = 600.px
+      maxHeight = 800.px
+    }
+    rule(".sample-app-container") {
+      display = Display.flex
+      justifyContent = JustifyContent.center
+      alignItems = Align.center
+    }
+  }
+
+  @Get("/styles/base.css") suspend fun assetStyle(request: HttpRequest<Any>) = stylesheet(request) {
+    module("styles.base")
+    assetType(AssetType.STYLESHEET)
+  }
+
+  @Get("/styles/base.another.css") suspend fun assetGeneric(request: HttpRequest<Any>) = asset(request) {
+    module("styles.base")
+    assetType(AssetType.STYLESHEET)
+  }
+
+  @Get("/styles/base.other.css") suspend fun assetStyleExplicit(request: HttpRequest<Any>) =
+    stylesheet(request, "styles.base")
+
+  @Get("/scripts/ui.js") suspend fun assetScript(request: HttpRequest<Any>) = script(request) {
+    module("scripts.ui")
+  }
+
+  @Get("/scripts/ui.other.js") suspend fun assetScriptExplicit(request: HttpRequest<Any>) =
+    script(request, "scripts.ui")
+
+  @Get("/something.txt") suspend fun somethingText() = staticFile(
+    "something.txt",
+    "text/plain",
+  )
+
+  @Get("/something-not-found.txt") suspend fun somethingMissing() = staticFile(
+    "something-not-found.txt",
+    "text/plain",
+  )
+}

--- a/packages/server/src/test/resources/static/something.txt
+++ b/packages/server/src/test/resources/static/something.txt
@@ -1,0 +1,1 @@
+here's a text file

--- a/packages/test/build.gradle.kts
+++ b/packages/test/build.gradle.kts
@@ -150,12 +150,20 @@ kotlin {
         implementation(libs.kotlinx.coroutines.jdk9)
         implementation(libs.kotlinx.coroutines.guava)
         implementation(libs.grpc.testing)
+        implementation(kotlin("test"))
         implementation(kotlin("test-junit5"))
         implementation(libs.jsoup)
 
         implementation(libs.truth)
         implementation(libs.truth.java8)
         implementation(libs.truth.proto)
+
+        implementation(libs.micronaut.context)
+        implementation(libs.micronaut.runtime)
+        implementation(libs.micronaut.test.junit5)
+        implementation(libs.micronaut.http)
+        implementation(libs.micronaut.http.client)
+        implementation(libs.micronaut.http.server)
 
         runtimeOnly(libs.junit.jupiter.engine)
         runtimeOnly(libs.logback)

--- a/packages/test/src/jvmMain/kotlin/elide/server/ElideServerTest.kt
+++ b/packages/test/src/jvmMain/kotlin/elide/server/ElideServerTest.kt
@@ -1,0 +1,155 @@
+package elide.server
+
+import io.micronaut.context.ApplicationContext
+import io.micronaut.context.BeanContext
+import io.micronaut.http.HttpHeaders
+import io.micronaut.http.HttpRequest
+import io.micronaut.http.HttpResponse
+import io.micronaut.http.MutableHttpRequest
+import io.micronaut.http.client.HttpClient
+import io.micronaut.runtime.server.EmbeddedServer
+import jakarta.inject.Inject
+import org.jsoup.Jsoup
+import org.jsoup.nodes.Document
+import java.net.URI
+import kotlin.test.assertEquals
+import kotlin.test.assertNotNull
+
+/** Base class for Micronaut tests which want to use the enclosed convenience functions. */
+@Suppress("unused", "RedundantVisibilityModifier", "UnnecessaryAbstractClass")
+public abstract class ElideServerTest {
+  // Application context.
+  @Inject public lateinit var context: ApplicationContext
+
+  // Bean context.
+  @Inject public lateinit var beanContext: BeanContext
+
+  // Embedded application server.
+  @Inject public lateinit var app: EmbeddedServer
+
+  // Embedded HTTP client.
+  @Inject public lateinit var client: HttpClient
+
+  /**
+   * Assert that the test is ready to run and has all locally injected resources.
+   */
+  protected fun assertReady() {
+    assertNotNull(app, "embedded app must be available for HTTP client testing")
+    assertNotNull(client, "embedded client must be available for HTTP client testing")
+  }
+
+  /**
+   * Exchange a test [request] with the current server, expecting [status] as an HTTP return status; after executing the
+   * request to obtain the response, [block] is executed (if provided) to perform additional assertions on the response.
+   *
+   * In this case, no response payload type is provided, and the request payload type is also generic. If you would like
+   * to decode the response and test against it, see other variants of this method.
+   *
+   * @see exchange which allows a response body type.
+   * @param request HTTP request to submit to the current Elide server.
+   * @param status Expected HTTP status for the response.
+   * @param block Block of assertions to additionally perform.
+   * @return HTTP response from the server.
+   */
+  @Suppress("HttpUrlsUsage")
+  public fun exchange(
+    request: MutableHttpRequest<Any>,
+    status: Int? = 200,
+    block: (HttpResponse<Any>.() -> Unit)? = null,
+  ): HttpResponse<Any> {
+    assertReady()
+    val req: HttpRequest<Any> = request.uri(
+      URI.create("http://${app.host}:${app.port}${request.uri}")
+    )
+    val client = client.toBlocking()
+    val response = client.exchange<Any, Any>(req)
+    assertNotNull(response, "should not get `null` response from Micronaut")
+    if (status != null) {
+      assertEquals(status, response.status.code, "expected status code '$status' did not match")
+    }
+    block?.let {
+      response.it()
+    }
+    return response
+  }
+
+  /**
+   * Exchange a test [request] with the current server, expecting [status] as an HTTP return status; after executing the
+   * request to obtain the response, [block] is executed (if provided) to perform additional assertions on the response.
+   *
+   * @param request HTTP request to submit to the current Elide server.
+   * @param status Expected HTTP status for the response.
+   * @param responseType Type of the response payload.
+   * @param block Block of assertions to additionally perform.
+   * @return HTTP response from the server.
+   */
+  @Suppress("HttpUrlsUsage")
+  public fun <P : Any, R : Any> exchange(
+    request: MutableHttpRequest<P>,
+    status: Int? = 200,
+    responseType: Class<R>,
+    block: (HttpResponse<R>.() -> Unit)? = null,
+  ): HttpResponse<R> {
+    assertReady()
+    val req: HttpRequest<P> = request.uri(
+      URI.create("http://${app.host}:${app.port}${request.uri}")
+    )
+    val client = client.toBlocking()
+    val response = client.exchange(
+      req,
+      responseType,
+    )
+    assertNotNull(response, "should not get `null` response from Micronaut")
+    if (status != null) {
+      assertEquals(status, response.status.code, "expected status code '$status' did not match")
+    }
+    block?.let {
+      response.it()
+    }
+    return response
+  }
+
+  /**
+   * Syntactic sugar to exchange a [request] with the active Elide server which is expected to produce HTML; assertions
+   * are run against the response (expected status, content-type/encoding/length, etc), and then the page is parsed with
+   * Jsoup and handed to [block] for additional testing.
+   *
+   * If any step of the parsing or fetching process fails, the test invoking this method also fails (unless such errors
+   * are caught by the invoker).
+   *
+   * @see exchange which allows an arbitrary response body type.
+   * @param request HTTP request to submit to the current Elide server.
+   * @param accept Accept value to append to the response; if `null` is passed, nothing is appended.
+   * @param status Expected HTTP status for the response.
+   * @param block Block of assertions to additionally perform, with access to the parsed page.
+   * @return HTTP response from the server.
+   */
+  @Suppress("HttpUrlsUsage")
+  public fun exchangeHTML(
+    request: MutableHttpRequest<Any>,
+    accept: String? = "text/html,*/*",
+    status: Int? = 200,
+    block: (HttpResponse<Any>.(Document) -> Unit)? = null,
+  ): HttpResponse<Any> {
+    assertReady()
+    if (accept != null && accept.isNotBlank()) {
+      request.headers[HttpHeaders.ACCEPT] = accept
+    }
+    val response = exchange(
+      request,
+      status,
+      Any::class.java,
+    ) {
+      // parse the page with jsoup so that assertions can run against it.
+      val page = Jsoup.parse(
+        getBody(String::class.java).orElseThrow {
+          IllegalStateException("Failed to decode response body into String to parse with JSoup.")
+        }
+      )
+      block?.let {
+        this.it(page)
+      }
+    }
+    return response
+  }
+}

--- a/samples/fullstack/basic/frontend/build.gradle.kts
+++ b/samples/fullstack/basic/frontend/build.gradle.kts
@@ -24,7 +24,7 @@ kotlin {
     binaries.executable()
     browser {
       commonWebpackConfig {
-        sourceMaps = devMode
+        sourceMaps = false
         cssSupport.enabled = true
         mode = if (devMode) {
           org.jetbrains.kotlin.gradle.targets.js.webpack.KotlinWebpackConfig.Mode.DEVELOPMENT
@@ -50,11 +50,11 @@ tasks.withType<Zip>{
   duplicatesStrategy = DuplicatesStrategy.EXCLUDE
 }
 
-val browserDist by configurations.creating {
+val assetDist by configurations.creating {
   isCanBeConsumed = true
   isCanBeResolved = false
 }
 
 artifacts {
-  add(browserDist.name, tasks.named("browserDistribution").map { it.outputs.files.files.single() })
+  add(assetDist.name, tasks.named("browserDistribution").map { it.outputs.files.files.single() })
 }

--- a/samples/fullstack/basic/server/build.gradle.kts
+++ b/samples/fullstack/basic/server/build.gradle.kts
@@ -15,6 +15,7 @@ plugins {
   alias(libs.plugins.micronautApplication)
   alias(libs.plugins.micronautAot)
   alias(libs.plugins.sonar)
+  id("dev.elide.buildtools.plugin")
 }
 
 group = "dev.elide.samples"
@@ -23,6 +24,16 @@ version = rootProject.version as String
 kotlin {
   jvmToolchain {
     languageVersion.set(JavaLanguageVersion.of((project.properties["versions.java.language"] as String)))
+  }
+}
+
+elide {
+  server {
+    assets {
+      script("scripts.ui") {
+        from(project(":samples:fullstack:basic:frontend"))
+      }
+    }
   }
 }
 
@@ -70,11 +81,6 @@ micronaut {
   }
 }
 
-val browserDist: Configuration by configurations.creating {
-  isCanBeConsumed = false
-  isCanBeResolved = true
-}
-
 dependencies {
   implementation(project(":packages:server"))
   implementation(libs.micronaut.context)
@@ -82,25 +88,10 @@ dependencies {
   implementation(libs.kotlinx.html.jvm)
   implementation(libs.kotlinx.wrappers.css)
   runtimeOnly(libs.logback)
-
-  browserDist(
-    project(
-      mapOf(
-        "path" to ":samples:fullstack:basic:frontend",
-        "configuration" to "browserDist"
-      )
-    )
-  )
 }
 
 tasks.withType<Copy>().named("processResources") {
-  dependsOn("copyJs")
   dependsOn("copyStatic")
-}
-
-tasks.register<Copy>("copyJs") {
-  from(browserDist)
-  into("$buildDir/resources/main/assets/js")
 }
 
 tasks.register<Copy>("copyStatic") {

--- a/samples/fullstack/basic/server/src/main/kotlin/fullstack/basic/App.kt
+++ b/samples/fullstack/basic/server/src/main/kotlin/fullstack/basic/App.kt
@@ -1,7 +1,11 @@
 package fullstack.basic
 
-import elide.server.*
-import io.micronaut.http.MediaType
+import elide.server.controller.PageController
+import elide.server.css
+import elide.server.html
+import elide.server.script
+import elide.server.stylesheet
+import io.micronaut.http.HttpRequest
 import io.micronaut.http.annotation.Controller
 import io.micronaut.http.annotation.Get
 import io.micronaut.runtime.Micronaut.build
@@ -13,11 +17,10 @@ import kotlinx.html.head
 import kotlinx.html.strong
 import kotlinx.html.title
 
-
 /** Self-contained application example, which serves an HTML page, with CSS, that says "Hello, Elide!". */
 object App {
   /** GET `/`: Controller for index page. */
-  @Controller class Index {
+  @Controller class Index : PageController() {
     // Serve the page itself.
     @Get("/") suspend fun index() = html {
       head {
@@ -41,11 +44,9 @@ object App {
     }
 
     // Serve the built & embedded JavaScript.
-    @Get("/scripts/ui.js") fun js() = asset(
-      "frontend.js",
-      "js",
-      MediaType("application/javascript", "js"),
-    )
+    @Get("/scripts/ui.js") suspend fun js(request: HttpRequest<Any>) = script(request) {
+      module("scripts.ui")
+    }
   }
 
   /** Main entrypoint for the application. */

--- a/samples/fullstack/react-ssr/server/build.gradle.kts
+++ b/samples/fullstack/react-ssr/server/build.gradle.kts
@@ -7,7 +7,6 @@
 
 import dev.elide.buildtools.gradle.plugin.BuildMode
 import tools.elide.assets.EmbeddedScriptLanguage
-import tools.elide.data.CompressionMode
 
 plugins {
   java
@@ -18,6 +17,7 @@ plugins {
   kotlin("plugin.allopen")
   kotlin("plugin.serialization")
   id("dev.elide.buildtools.plugin")
+  alias(libs.plugins.testLogger)
   alias(libs.plugins.micronautApplication)
   alias(libs.plugins.micronautAot)
   alias(libs.plugins.sonar)
@@ -171,11 +171,17 @@ dependencies {
   implementation(project(":packages:server"))
   implementation(project(":packages:graalvm"))
 
+  implementation(libs.jsoup)
   implementation(libs.micronaut.context)
   implementation(libs.micronaut.runtime)
   implementation(libs.kotlinx.html.jvm)
   implementation(libs.kotlinx.wrappers.css)
   runtimeOnly(libs.logback)
+
+  testImplementation(kotlin("test"))
+  testImplementation(kotlin("test-junit5"))
+  testImplementation(project(":packages:test"))
+  testImplementation(libs.micronaut.test.junit5)
 }
 
 tasks.withType<Tar> {

--- a/samples/fullstack/react-ssr/server/src/main/kotlin/fullstack/reactssr/App.kt
+++ b/samples/fullstack/react-ssr/server/src/main/kotlin/fullstack/reactssr/App.kt
@@ -18,7 +18,7 @@ object App : Application {
     @Get("/") suspend fun indexPage(request: HttpRequest<*>) = ssr(request) {
       head {
         title { +"Hello, Elide!" }
-        stylesheet("/styles/base.css")
+        stylesheet(asset("styles.base"))
         stylesheet("/styles/main.css")
         script("/scripts/ui.js", defer = true)
       }

--- a/samples/fullstack/react-ssr/server/src/test/kotlin/fullstack/reactssr/AppTest.kt
+++ b/samples/fullstack/react-ssr/server/src/test/kotlin/fullstack/reactssr/AppTest.kt
@@ -1,0 +1,164 @@
+package fullstack.reactssr
+
+import elide.server.ElideServerTest
+import io.micronaut.http.HttpRequest
+import io.micronaut.test.extensions.junit5.annotation.MicronautTest
+import jakarta.inject.Inject
+import org.junit.jupiter.api.Test
+import java.nio.charset.StandardCharsets
+import kotlin.test.assertEquals
+import kotlin.test.assertNotNull
+import kotlin.test.assertTrue
+
+/** Example testsuite for the fullstack React SSR app sample ([App]). */
+@MicronautTest class AppTest : ElideServerTest() {
+  @Inject lateinit var index: App.Index
+
+  // Make sure the handler can be injected.
+  @Test fun testInjectable() {
+    assertNotNull(index, "should be able to inject an instance of the `Index` controller")
+  }
+
+  // Make sure the index page (`/`) doesn't error and yields an HTTP 200.
+  @Test fun testFetchIndex() {
+    exchange(HttpRequest.GET("/")) {
+      assertEquals(
+        200,
+        status.code,
+        "status code should be '200' for index page"
+      )
+      assertTrue(
+        headers.contains("Content-Type"),
+        "response should specify a `Content-Type` header"
+      )
+      assertTrue(
+        headers.get("Content-Type")!!.contains("text/html"),
+        "`Content-Type` should include `text/html` from index page"
+      )
+      assertTrue(
+        headers.contains("Content-Length"),
+        "response should specify a `Content-Length` header"
+      )
+      assertNotNull(
+        headers.get("Content-Length")!!.toLongOrNull(),
+        "`Content-Length` should decode as a number"
+      )
+      assertTrue(
+        headers.get("Content-Length")!!.toLong() > 0,
+        "`Content-Length` should be greater than zero"
+      )
+    }
+  }
+
+  // Decode the returned page as HTML and assert against the structure.
+  @Test fun testFetchIndexContent() {
+    exchangeHTML(HttpRequest.GET("/")) {
+      // you can still do basic assertions, because `this` == `HttpResponse`
+      assertEquals(
+        200,
+        status.code,
+        "status code should be '200' for index page"
+      )
+      assertTrue(
+        headers.contains("Content-Type"),
+        "response should specify a `Content-Type` header"
+      )
+      assertTrue(
+        headers.get("Content-Type")!!.contains("text/html"),
+        "`Content-Type` should include `text/html` from index page"
+      )
+
+      // assert basic page details
+      assertEquals(StandardCharsets.UTF_8, it.charset())
+      assertEquals("Hello, Elide!", it.title())
+
+      // make sure the styles made it in
+      val styleLinks = it.head().getElementsByTag("link").toList().filter { link ->
+        link.attr("rel") == "stylesheet"
+      }
+      assertEquals(2, styleLinks.size, "should have 2 stylesheet links in the resulting page")
+      val mainCss = styleLinks.find { link -> link.attr("href").contains("main.css") }
+      assertNotNull(mainCss, "main.css should be findable in page output")
+
+      // body assertions for SSR
+      val root = it.body().getElementById("root")
+      assertNotNull(root, "should be able to find root content element for React at `#root`")
+      assertEquals("ssr", root.attr("data-serving-mode"), "serving-mode should be `ssr`")
+      assertTrue(
+        root.html().contains("Hello, Elide!")
+      )
+    }
+  }
+
+  @Test fun testFetchStaticCss() {
+    exchange(HttpRequest.GET("/styles/main.css")) {
+      assertEquals(
+        200,
+        status.code,
+        "status code should be '200' for static CSS"
+      )
+      assertTrue(
+        headers.contains("Content-Type"),
+        "response should specify a `Content-Type` header"
+      )
+      assertTrue(
+        headers.get("Content-Type")!!.contains("text/css"),
+        "`Content-Type` header should include `text/css`"
+      )
+    }
+  }
+
+  @Test fun testFetchAssetCss() {
+    // should be fetchable at the bound custom URL
+    exchange(HttpRequest.GET(index.asset("styles.base").href)) {
+      assertEquals(
+        200,
+        status.code,
+        "status code should be '200' for asset CSS"
+      )
+      assertTrue(
+        headers.contains("Content-Type"),
+        "response should specify a `Content-Type` header"
+      )
+      assertTrue(
+        headers.get("Content-Type")!!.contains("text/css"),
+        "`Content-Type` header should include `text/css`"
+      )
+    }
+
+    // should also be fetchable at the generated URL
+    exchange(HttpRequest.GET("/styles/base.css")) {
+      assertEquals(
+        200,
+        status.code,
+        "status code should be '200' for asset CSS"
+      )
+      assertTrue(
+        headers.contains("Content-Type"),
+        "response should specify a `Content-Type` header"
+      )
+      assertTrue(
+        headers.get("Content-Type")!!.contains("text/css"),
+        "`Content-Type` header should include `text/css`"
+      )
+    }
+  }
+
+  @Test fun testFetchStaticJs() {
+    exchange(HttpRequest.GET("/scripts/ui.js")) {
+      assertEquals(
+        200,
+        status.code,
+        "status code should be '200' for client-side JS"
+      )
+      assertTrue(
+        headers.contains("Content-Type"),
+        "response should specify a `Content-Type` header"
+      )
+      assertTrue(
+        headers.get("Content-Type")!!.contains("application/javascript"),
+        "`Content-Type` header should include `application/javascript`"
+      )
+    }
+  }
+}

--- a/samples/fullstack/react-ssr/server/src/test/resources/logback.xml
+++ b/samples/fullstack/react-ssr/server/src/test/resources/logback.xml
@@ -1,0 +1,12 @@
+<configuration>
+    <appender name="STDOUT" class="ch.qos.logback.core.ConsoleAppender">
+        <withJansi>true</withJansi>
+        <encoder>
+            <pattern>%cyan(%d{HH:mm:ss.SSS}) %gray([%thread]) %highlight(%-5level) %magenta(react-ssr) - %msg%n</pattern>
+        </encoder>
+    </appender>
+
+    <root level="info">
+        <appender-ref ref="STDOUT" />
+    </root>
+</configuration>

--- a/samples/fullstack/react/frontend/build.gradle.kts
+++ b/samples/fullstack/react/frontend/build.gradle.kts
@@ -24,7 +24,7 @@ kotlin {
     binaries.executable()
     browser {
       commonWebpackConfig {
-        sourceMaps = devMode
+        sourceMaps = false
         cssSupport.enabled = true
         mode = if (devMode) {
           org.jetbrains.kotlin.gradle.targets.js.webpack.KotlinWebpackConfig.Mode.DEVELOPMENT
@@ -52,11 +52,11 @@ tasks.withType<Zip>{
   duplicatesStrategy = DuplicatesStrategy.EXCLUDE
 }
 
-val browserDist by configurations.creating {
+val assetDist by configurations.creating {
   isCanBeConsumed = true
   isCanBeResolved = false
 }
 
 artifacts {
-  add(browserDist.name, tasks.named("browserDistribution").map { it.outputs.files.files.single() })
+  add(assetDist.name, tasks.named("browserDistribution").map { it.outputs.files.files.single() })
 }

--- a/samples/fullstack/react/server/build.gradle.kts
+++ b/samples/fullstack/react/server/build.gradle.kts
@@ -15,6 +15,7 @@ plugins {
   alias(libs.plugins.micronautApplication)
   alias(libs.plugins.micronautAot)
   alias(libs.plugins.sonar)
+  id("dev.elide.buildtools.plugin")
 }
 
 group = "dev.elide.samples"
@@ -23,6 +24,16 @@ version = rootProject.version as String
 kotlin {
   jvmToolchain {
     languageVersion.set(JavaLanguageVersion.of((project.properties["versions.java.language"] as String)))
+  }
+}
+
+elide {
+  server {
+    assets {
+      script("scripts.ui") {
+        from(project(":samples:fullstack:react:frontend"))
+      }
+    }
   }
 }
 
@@ -70,11 +81,6 @@ micronaut {
   }
 }
 
-val browserDist: Configuration by configurations.creating {
-  isCanBeConsumed = false
-  isCanBeResolved = true
-}
-
 dependencies {
   implementation(project(":packages:server"))
   implementation(libs.micronaut.context)
@@ -82,25 +88,10 @@ dependencies {
   implementation(libs.kotlinx.html.jvm)
   implementation(libs.kotlinx.wrappers.css)
   runtimeOnly(libs.logback)
-
-  browserDist(
-    project(
-      mapOf(
-        "path" to ":samples:fullstack:react:frontend",
-        "configuration" to "browserDist"
-      )
-    )
-  )
 }
 
 tasks.withType<Copy>().named("processResources") {
-  dependsOn("copyJs")
   dependsOn("copyStatic")
-}
-
-tasks.register<Copy>("copyJs") {
-  from(browserDist)
-  into("$buildDir/resources/main/assets/js")
 }
 
 tasks.register<Copy>("copyStatic") {

--- a/samples/fullstack/react/server/src/main/kotlin/fullstack/react/App.kt
+++ b/samples/fullstack/react/server/src/main/kotlin/fullstack/react/App.kt
@@ -1,7 +1,8 @@
 package fullstack.react
 
 import elide.server.*
-import io.micronaut.http.MediaType
+import elide.server.controller.PageController
+import io.micronaut.http.HttpRequest
 import io.micronaut.http.annotation.Controller
 import io.micronaut.http.annotation.Get
 import io.micronaut.runtime.Micronaut.build
@@ -13,11 +14,10 @@ import kotlinx.html.head
 import kotlinx.html.strong
 import kotlinx.html.title
 
-
 /** Self-contained application example, which serves an HTML page, with CSS, that says "Hello, Elide!". */
 object App {
   /** GET `/`: Controller for index page. */
-  @Controller class Index {
+  @Controller class Index : PageController() {
     // Serve the page itself.
     @Get("/") suspend fun index() = html {
       head {
@@ -41,11 +41,9 @@ object App {
     }
 
     // Serve the built & embedded JavaScript.
-    @Get("/scripts/ui.js") fun js() = asset(
-      "frontend.js",
-      "js",
-      MediaType("application/javascript", "js"),
-    )
+    @Get("/scripts/ui.js") suspend fun js(request: HttpRequest<Any>) = script(request) {
+      module("scripts.ui")
+    }
   }
 
   /** Main entrypoint for the application. */

--- a/samples/server/hellocss/src/main/kotlin/hellocss/App.kt
+++ b/samples/server/hellocss/src/main/kotlin/hellocss/App.kt
@@ -14,7 +14,6 @@ import kotlinx.html.head
 import kotlinx.html.strong
 import kotlinx.html.title
 
-
 /** Self-contained application example, which serves an HTML page, with CSS, that says "Hello, Elide!". */
 object App {
   /** GET `/`: Controller for index page. */


### PR DESCRIPTION
![Ready for review](https://badgen.net/badge/Status/Ready%20for%20review/green) [<img width="16" alt="Powered by Pull Request Badge" src="https://user-images.githubusercontent.com/1393946/111216524-d2bb8e00-85d4-11eb-821b-ed4c00989c02.png">](https://pullrequestbadge.com/?utm_medium=github&utm_source=elide-dev&utm_campaign=badge_info)<!-- PR-BADGE: PLEASE DO NOT REMOVE THIS COMMENT -->

This changeset introduces asset references, which can be used from an Elide `PageController` to reference an asset module
embedded within the application.

Elide will generate a relative URL for the asset where it will be served by the built-in asset controller.

### Changelog

- [x] Add extension variants which work on `AssetReference` objects
- [x] Generate `AssetReference` objects with a new `asset()` method
- [x] Change `AssetPointer` to carry the original asset tag
- [x] Amend tests accordingly
- [x] Introduce first sample-app testsuite using new test base class
- [x] Tests for `PageController`