### PR TITLE
Feature: Builtin Handlers

### DIFF
--- a/packages/server/src/main/kotlin/elide/server/controller/builtin/BuiltinController.kt
+++ b/packages/server/src/main/kotlin/elide/server/controller/builtin/BuiltinController.kt
@@ -1,0 +1,59 @@
+package elide.server.controller.builtin
+
+import elide.server.RawResponse
+import elide.server.controller.BaseController
+import elide.server.controller.PageController
+import elide.server.controller.StatusEnabledController
+import elide.server.runtime.UncaughtExceptionHandler
+import io.micronaut.http.HttpRequest
+
+/**
+ * Base class for built-in controllers provided by Elide.
+ *
+ * "Built-in" controllers are mounted within the application context by default, and handle events like global
+ * `404 Not Found` and upstream call failures.
+ *
+ * ### Built-in controllers
+ *
+ * Each built-in controller operates at the default `@Singleton` scope, and complies with [StatusEnabledController]. As
+ * such, state tied to individual requests is not allowed on built-in controllers unless proper synchronization is used.
+ *
+ * Users can replace built-in controllers via Micronaut annotations. See below for more.
+ *
+ * ### Overriding built-in controllers
+ *
+ * To override a built-in controller, implement [BaseController] and annotate your class as follows:
+ * ```kotlin
+ * @Controller
+ * @Replaces(SomeBuiltinController::class)
+ * class MyController {
+ *   // ...
+ * }
+ * ```
+ *
+ * ### Default built-in controllers
+ *
+ * The following built-in controllers are provided by the framework by default:
+ * - [NotFoundController]: handles `404 Not Found` events by rendering a designated HTML template.
+ * - [ServerErrorController]: handles generic `500 Internal Server Error` events via a designated HTML template.
+ *
+ * ### Low-level error handler
+ *
+ * General/low-level error handling is provided at the executor level by [UncaughtExceptionHandler], which can also be
+ * customized / replaced via the same mechanism shown above. See docs on that class for more info.
+ *
+ * @see NotFoundController for the built-in controller which handles `404 Not Found` events.
+ * @see ServerErrorController for the built-in controller which handles generic internal error events.
+ * @see UncaughtExceptionHandler for customizable background error handling logic.
+ */
+public abstract class BuiltinController : StatusEnabledController, PageController() {
+  /**
+   * Handles a request to this built-in controller.
+   *
+   * To perform I/O or any other blocking task, this method should suspend against the appropriate dispatcher.
+   *
+   * @param request Subject request to handle.
+   * @return HTTP response which should be returned in response to the provided [request].
+   */
+  public abstract suspend fun handle(request: HttpRequest<out Any>): RawResponse
+}

--- a/packages/server/src/main/kotlin/elide/server/controller/builtin/NotFoundController.kt
+++ b/packages/server/src/main/kotlin/elide/server/controller/builtin/NotFoundController.kt
@@ -1,0 +1,65 @@
+package elide.server.controller.builtin
+
+import elide.server.RawPayload
+import elide.server.RawResponse
+import elide.server.annotations.Eager
+import elide.server.html
+import io.micronaut.http.HttpRequest
+import io.micronaut.http.HttpResponse
+import io.micronaut.http.HttpStatus
+import io.micronaut.http.MediaType
+import io.micronaut.http.annotation.Controller
+import io.micronaut.http.annotation.Error
+import io.micronaut.http.annotation.Get
+import kotlinx.html.h1
+import kotlinx.html.p
+import kotlinx.html.tagext.body
+import kotlinx.html.tagext.head
+import kotlinx.html.title
+import java.io.ByteArrayOutputStream
+
+/** Default built-in controller which handles `404 Not Found` events. */
+@Eager @Controller public class NotFoundController : BuiltinController() {
+  /** @inheritDoc */
+  @Get("/error/notfound", produces = [
+    MediaType.TEXT_HTML,
+    MediaType.APPLICATION_JSON,
+  ])
+  @Error(status = HttpStatus.NOT_FOUND, global = true)
+  override suspend fun handle(request: HttpRequest<out Any>): RawResponse {
+    val accept = (request.accept() ?: listOf(MediaType.TEXT_HTML)).map { it.toString() }
+    return when {
+      accept.contains(MediaType.TEXT_HTML) -> serveHTMLNotFound()
+      accept.contains(MediaType.APPLICATION_JSON) -> serveJSONNotFound()
+      else -> servePlaintext()
+    }
+  }
+
+  // Serve a 404 in HTML.
+  private suspend fun serveHTMLNotFound(): RawResponse = html {
+    html {
+      head {
+        title { +"Not Found" }
+      }
+      body {
+        h1 { +"Not Found" }
+        p { +"The requested resource was not found." }
+      }
+    }
+  }
+
+  // Serve a 404 in JSON.
+  private fun serveJSONNotFound(): RawResponse {
+    return HttpResponse.notFound<RawPayload>().contentType(MediaType.APPLICATION_JSON)
+  }
+
+  private fun servePlaintext(): RawResponse {
+    val baos = ByteArrayOutputStream()
+    baos.use {
+      it.writeBytes("Not found.".toByteArray())
+    }
+    return HttpResponse.notFound<RawPayload>().contentType(MediaType.TEXT_PLAIN).body(
+      baos
+    )
+  }
+}

--- a/packages/server/src/main/kotlin/elide/server/controller/builtin/ServerErrorController.kt
+++ b/packages/server/src/main/kotlin/elide/server/controller/builtin/ServerErrorController.kt
@@ -1,0 +1,63 @@
+package elide.server.controller.builtin
+
+import elide.server.RawPayload
+import elide.server.RawResponse
+import elide.server.annotations.Eager
+import elide.server.html
+import io.micronaut.http.HttpRequest
+import io.micronaut.http.HttpResponse
+import io.micronaut.http.HttpStatus
+import io.micronaut.http.MediaType
+import io.micronaut.http.annotation.Controller
+import io.micronaut.http.annotation.Error
+import io.micronaut.http.annotation.Get
+import kotlinx.html.h1
+import kotlinx.html.p
+import kotlinx.html.tagext.body
+import kotlinx.html.tagext.head
+import kotlinx.html.title
+import java.io.ByteArrayOutputStream
+
+/** Default built-in controller which handles `500 Internal Server Error` events. */
+@Eager @Controller public class ServerErrorController : BuiltinController() {
+  /** @inheritDoc */
+  @Get("/error/internal", produces = [MediaType.TEXT_HTML])
+  @Error(status = HttpStatus.INTERNAL_SERVER_ERROR, global = true)
+  override suspend fun handle(request: HttpRequest<out Any>): RawResponse {
+    val accept = (request.accept() ?: listOf(MediaType.TEXT_HTML)).map { it.toString() }
+    return when {
+      accept.contains(MediaType.TEXT_HTML) -> serveHTMLError()
+      accept.contains(MediaType.APPLICATION_JSON) -> serveJSONError()
+      else -> servePlaintext()
+    }
+  }
+
+  // Serve a 500 in HTML.
+  private suspend fun serveHTMLError(): RawResponse = html {
+    html {
+      head {
+        title { +"Uh oh" }
+      }
+      body {
+        h1 { +"Something went wrong" }
+        p { +"Please try again later." }
+      }
+    }
+  }
+
+  // Serve a 500 in JSON.
+  private fun serveJSONError(): RawResponse {
+    return HttpResponse.serverError<RawPayload>().contentType(MediaType.APPLICATION_JSON)
+  }
+
+  // Serve a 500 in plaintext.
+  private fun servePlaintext(): RawResponse {
+    val baos = ByteArrayOutputStream()
+    baos.use {
+      it.writeBytes("Not found.".toByteArray())
+    }
+    return HttpResponse.serverError<RawPayload>().contentType(MediaType.TEXT_PLAIN).body(
+      baos
+    )
+  }
+}

--- a/packages/server/src/test/kotlin/elide/server/controller/builtin/BuiltinControllerTest.kt
+++ b/packages/server/src/test/kotlin/elide/server/controller/builtin/BuiltinControllerTest.kt
@@ -1,0 +1,73 @@
+package elide.server.controller.builtin
+
+import elide.server.RawResponse
+import io.micronaut.http.HttpMethod
+import io.micronaut.http.HttpRequest
+import io.micronaut.http.MediaType
+import io.micronaut.http.MutableHttpRequest
+import kotlinx.coroutines.runBlocking
+import org.junit.jupiter.params.ParameterizedTest
+import org.junit.jupiter.params.provider.CsvSource
+import kotlin.test.assertEquals
+import kotlin.test.assertNotNull
+
+/** Tests for built-in controllers, which handle HTML, text, and JSON. */
+abstract class BuiltinControllerTest<C : BuiltinController> {
+  /**
+   * Spawn a request to test this built-in controller.
+   *
+   * @param method HTTP method for which a request is needed.
+   * @return Request template to use. It will be mutated into different tests.
+   */
+  abstract fun getRequestTemplate(method: HttpMethod = HttpMethod.GET): MutableHttpRequest<Any>
+
+  /**
+   * @return Controller instance to test against.
+   */
+  abstract fun controller(): C
+
+  /**
+   * Execute the provided [request] against the built-in controller.
+   *
+   * @param controller Controller instance to test against.
+   * @param request Request to run against the controller.
+   */
+  open suspend fun executeRequest(controller: C, request: HttpRequest<Any>): RawResponse {
+    return controller.handle(request)
+  }
+
+  private fun builtinResponseAssertions(response: RawResponse?, mediaType: MediaType? = null) {
+    assertNotNull(response)
+    if (mediaType != null) {
+      assertEquals(mediaType, response.contentType.get())
+    }
+  }
+
+  @CsvSource(MediaType.APPLICATION_JSON, MediaType.TEXT_HTML, MediaType.TEXT_PLAIN)
+  @ParameterizedTest fun testRespondsToContentTypes(accept: MediaType) {
+    val controller = controller()
+    assertNotNull(controller)
+    val request = getRequestTemplate()
+    val response = runBlocking {
+      executeRequest(controller, request.accept(accept))
+    }
+    builtinResponseAssertions(
+      response,
+      accept
+    )
+  }
+
+  @CsvSource("GET", "PUT", "POST", "DELETE", "OPTIONS")
+  @ParameterizedTest fun testRespondsToMethods(method: String) {
+    val methodTarget = HttpMethod.valueOf(method)
+    val controller = controller()
+    assertNotNull(controller)
+    val request = getRequestTemplate(methodTarget)
+    val response = runBlocking {
+      executeRequest(controller, request)
+    }
+    builtinResponseAssertions(
+      response,
+    )
+  }
+}

--- a/packages/server/src/test/kotlin/elide/server/controller/builtin/NotFoundControllerTest.kt
+++ b/packages/server/src/test/kotlin/elide/server/controller/builtin/NotFoundControllerTest.kt
@@ -1,0 +1,26 @@
+package elide.server.controller.builtin
+
+import io.micronaut.http.HttpMethod
+import io.micronaut.http.HttpRequest
+import io.micronaut.http.MutableHttpRequest
+import io.micronaut.test.extensions.junit5.annotation.MicronautTest
+import jakarta.inject.Inject
+import kotlin.test.Test
+import kotlin.test.assertNotNull
+
+/** Contract tests for [NotFoundController]. */
+@MicronautTest class NotFoundControllerTest : BuiltinControllerTest<NotFoundController>() {
+  @Inject lateinit var controller: NotFoundController
+
+  @Test fun testInjectable() {
+    assertNotNull(controller)
+  }
+
+  override fun controller(): NotFoundController {
+    return controller
+  }
+
+  override fun getRequestTemplate(method: HttpMethod): MutableHttpRequest<Any> {
+    return HttpRequest.create(method, "/error/notfound")
+  }
+}

--- a/packages/server/src/test/kotlin/elide/server/controller/builtin/ServerErrorControllerTest.kt
+++ b/packages/server/src/test/kotlin/elide/server/controller/builtin/ServerErrorControllerTest.kt
@@ -1,0 +1,26 @@
+package elide.server.controller.builtin
+
+import io.micronaut.http.HttpMethod
+import io.micronaut.http.HttpRequest
+import io.micronaut.http.MutableHttpRequest
+import io.micronaut.test.extensions.junit5.annotation.MicronautTest
+import jakarta.inject.Inject
+import kotlin.test.Test
+import kotlin.test.assertNotNull
+
+/** Contract tests for [ServerErrorController]. */
+@MicronautTest class ServerErrorControllerTest : BuiltinControllerTest<ServerErrorController>() {
+  @Inject lateinit var controller: ServerErrorController
+
+  @Test fun testInjectable() {
+    assertNotNull(controller)
+  }
+
+  override fun controller(): ServerErrorController {
+    return controller
+  }
+
+  override fun getRequestTemplate(method: HttpMethod): MutableHttpRequest<Any> {
+    return HttpRequest.create(method, "/error/internal")
+  }
+}


### PR DESCRIPTION
![Ready for review](https://badgen.net/badge/Status/Ready%20for%20review/green) [<img width="16" alt="Powered by Pull Request Badge" src="https://user-images.githubusercontent.com/1393946/111216524-d2bb8e00-85d4-11eb-821b-ed4c00989c02.png">](https://pullrequestbadge.com/?utm_medium=github&utm_source=elide-dev&utm_campaign=badge_info)<!-- PR-BADGE: PLEASE DO NOT REMOVE THIS COMMENT -->

This changeset introduces the concept of _Built-in Handlers_, which are installed into the application context by default, and may be overridden at the developer's discretion.

These handlers are designed to implement baseline app functionality so that an out-of-the-box Elide app behaves as expected on the web.

### Changelog
- [x] Add concept of "built-in handlers" with `BuiltinController`
- [x] Add built-in controller for `404 Not Found` events
- [x] Add built-in controller for `500 Internal Server Error` events
- [x] Add support for JSON, HTML, and plaintext responses from new built-in controllers
- [x] Add tests for new built-in controllers